### PR TITLE
Add __main__ demos and update configs

### DIFF
--- a/Agent/__init__.py
+++ b/Agent/__init__.py
@@ -3,5 +3,23 @@
 from .phm_agent import PHMAgent
 from .report_agent import ReportAgent
 from .deep_research_agent import create_deep_research_agent
+from .sp1d_specialist_agent import SP1DSpecialistAgent
+from .sp2d_specialist_agent import SP2DSpecialistAgent
+from .stats_feature_agent import StatsFeatureAgent
+from .physical_feature_agent import PhysicalFeatureAgent
+from .retrieval_agent import RetrievalAgent
 
-__all__ = ["PHMAgent", "ReportAgent", "create_deep_research_agent"]
+__all__ = [
+    "PHMAgent",
+    "ReportAgent",
+    "create_deep_research_agent",
+    "SP1DSpecialistAgent",
+    "SP2DSpecialistAgent",
+    "StatsFeatureAgent",
+    "PhysicalFeatureAgent",
+    "RetrievalAgent",
+]
+
+
+if __name__ == "__main__":
+    print("Available agents:", __all__)

--- a/Agent/deep_research_agent.py
+++ b/Agent/deep_research_agent.py
@@ -97,3 +97,12 @@ def create_deep_research_agent(model: LiteLLMModel) -> ToolCallingAgent:
     return agent
 
 __all__ = ["create_deep_research_agent"]
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = create_deep_research_agent(DummyModel())
+    print("DeepResearch agent tools:", [t.name for t in agent.tools[:3]], "...")

--- a/Agent/phm_agent.py
+++ b/Agent/phm_agent.py
@@ -36,3 +36,12 @@ class PHMAgent(ToolCallingAgent):
             **kwargs,
         )
 
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = PHMAgent([], DummyModel())
+    print("Created PHMAgent with", len(agent.tools), "tools")
+

--- a/Agent/physical_feature_agent.py
+++ b/Agent/physical_feature_agent.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Agent for analysing physical fault signatures."""
+
+from typing import Any
+
+from smolagents.agents import ToolCallingAgent
+from smolagents.models import Model
+
+from PHM_tools.Signal_processing import envelope_spectrum
+from PHM_tools.Feature_extracting import extract_time_features
+from utils.registry import register_agent
+
+
+@register_agent("PhysicalFeatureAgent")
+class PhysicalFeatureAgent(ToolCallingAgent):
+    """Agent specialised in physics-based feature analysis."""
+
+    def __init__(self, model: Model, **kwargs: Any) -> None:
+        tools = [envelope_spectrum, extract_time_features]
+        instructions = "Analyse physical fault signatures using available tools."
+        super().__init__(
+            tools=tools,
+            model=model,
+            name="physical_feature_agent",
+            description="Analyses physics-based features",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = PhysicalFeatureAgent(DummyModel())
+    print("Physical tools:", [t.name for t in agent.tools])

--- a/Agent/report_agent.py
+++ b/Agent/report_agent.py
@@ -58,3 +58,12 @@ class ReportAgent(CodeAgent):
             add_base_tools=True,
             **kwargs,
         )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = ReportAgent(DummyModel())
+    print("Report agent with sub-agents:", [a.name for a in agent.managed_agents])

--- a/Agent/retrieval_agent.py
+++ b/Agent/retrieval_agent.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Agent for querying the PHM knowledge base."""
+
+from typing import Any
+
+from smolagents.agents import ToolCallingAgent
+from smolagents.models import Model
+
+from PHM_tools.Retrieval import create_local_retriever_tool
+from utils.registry import register_agent
+
+
+@register_agent("RetrievalAgent")
+class RetrievalAgent(ToolCallingAgent):
+    """Simple retrieval agent using vector search."""
+
+    def __init__(self, model: Model, kb_directory: str = "./kb", **kwargs: Any) -> None:
+        tool = create_local_retriever_tool(kb_directory)
+        instructions = "Use the retriever tool to fetch documents related to a query."
+        super().__init__(
+            tools=[tool],
+            model=model,
+            name="retrieval_agent",
+            description="Queries the vector knowledge base",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = RetrievalAgent(DummyModel(), kb_directory="./")
+    print("Retriever tool name:", agent.tools[0].name)

--- a/Agent/sp1d_specialist_agent.py
+++ b/Agent/sp1d_specialist_agent.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Specialist agent focused on 1-D signal processing."""
+
+from typing import Any
+
+from smolagents.agents import ToolCallingAgent
+from smolagents.models import Model
+
+from PHM_tools.Signal_processing import (
+    normalize,
+    detrend,
+    fft,
+    cepstrum,
+    envelope_spectrum,
+)
+from utils.registry import register_agent
+
+
+@register_agent("SP1D_SpecialistAgent")
+class SP1DSpecialistAgent(ToolCallingAgent):
+    """Agent wrapping common 1-D signal processing tools."""
+
+    def __init__(self, model: Model, **kwargs: Any) -> None:
+        tools = [normalize, detrend, fft, cepstrum, envelope_spectrum]
+        instructions = "Apply 1-D signal processing tools as requested."
+        super().__init__(
+            tools=tools,
+            model=model,
+            name="sp1d_specialist",
+            description="Expert in 1-D signal processing",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = SP1DSpecialistAgent(DummyModel())
+    print("Available tools:", [t.name for t in agent.tools])

--- a/Agent/sp2d_specialist_agent.py
+++ b/Agent/sp2d_specialist_agent.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Specialist agent for 2-D signal representations."""
+
+from typing import Any
+
+from smolagents.agents import ToolCallingAgent
+from smolagents.models import Model
+
+from PHM_tools.Signal_processing import (
+    spectrogram,
+    mel_spectrogram,
+    scalogram,
+)
+from utils.registry import register_agent
+
+
+@register_agent("SP2D_SpecialistAgent")
+class SP2DSpecialistAgent(ToolCallingAgent):
+    """Agent providing 2-D signal processing capabilities."""
+
+    def __init__(self, model: Model, **kwargs: Any) -> None:
+        tools = [spectrogram, mel_spectrogram, scalogram]
+        instructions = "Produce 2-D signal representations as needed."
+        super().__init__(
+            tools=tools,
+            model=model,
+            name="sp2d_specialist",
+            description="Expert in 2-D signal processing",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = SP2DSpecialistAgent(DummyModel())
+    print("Tools:", [t.name for t in agent.tools])

--- a/Agent/stats_feature_agent.py
+++ b/Agent/stats_feature_agent.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Agent dedicated to extracting statistical features."""
+
+from typing import Any
+
+from smolagents.agents import ToolCallingAgent
+from smolagents.models import Model
+
+from PHM_tools.Feature_extracting import (
+    extract_time_features,
+    extract_frequency_features,
+)
+from utils.registry import register_agent
+
+
+@register_agent("StatsFeatureAgent")
+class StatsFeatureAgent(ToolCallingAgent):
+    """Agent that extracts time and frequency features."""
+
+    def __init__(self, model: Model, **kwargs: Any) -> None:
+        tools = [extract_time_features, extract_frequency_features]
+        instructions = "Extract statistical features from signals."
+        super().__init__(
+            tools=tools,
+            model=model,
+            name="stats_feature_agent",
+            description="Computes statistical features",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = StatsFeatureAgent(DummyModel())
+    print("Feature tools:", [t.name for t in agent.tools])

--- a/PHM_tools/Anomaly_Detection/__init__.py
+++ b/PHM_tools/Anomaly_Detection/__init__.py
@@ -1,0 +1,16 @@
+"""Anomaly detection utilities for PHM_Agent."""
+
+from .signal_comparison import calculate_statistical_divergence
+
+__all__ = ["calculate_statistical_divergence"]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    a = np.random.randn(100)
+    b = np.random.randn(100)
+    from .signal_comparison import calculate_statistical_divergence
+
+    res = calculate_statistical_divergence(a.tolist(), b.tolist())
+    print("Divergence sample:", res)

--- a/PHM_tools/Anomaly_Detection/signal_comparison.py
+++ b/PHM_tools/Anomaly_Detection/signal_comparison.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""直接在信号层面对比，用于检测细微或非平稳变化的工具。"""
+
+from typing import Dict, List
+
+import numpy as np
+from smolagents import tool
+
+from utils.registry import register_tool
+
+
+@register_tool("calculate_statistical_divergence")
+@tool
+def calculate_statistical_divergence(
+    series_a: List[float], series_b: List[float], method: str = "kl"
+) -> Dict[str, float | str]:
+    """计算两个信号分布的差异以检测状态变化。
+
+    Args:
+        series_a: 在线信号序列。
+        series_b: 参考信号序列。
+        method: 散度计算方法, ``'kl'``或 ``'js'``。
+
+    Returns:
+        包含散度值和所用方法的字典, 例如 ``{"divergence": 0.08, "method": "kl"}``。
+    """
+    a = np.asarray(series_a, dtype=float)
+    b = np.asarray(series_b, dtype=float)
+    hist_a, _ = np.histogram(a, bins=100, density=True)
+    hist_b, _ = np.histogram(b, bins=100, density=True)
+    hist_a += 1e-12
+    hist_b += 1e-12
+    p = hist_a / hist_a.sum()
+    q = hist_b / hist_b.sum()
+
+    if method == "kl":
+        divergence = float(np.sum(p * np.log(p / q)))
+    elif method == "js":
+        m = 0.5 * (p + q)
+        divergence = float(
+            0.5 * np.sum(p * np.log(p / m)) + 0.5 * np.sum(q * np.log(q / m))
+        )
+    else:
+        raise ValueError(f"Unsupported method '{method}'")
+
+    return {"divergence": divergence, "method": method}
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    series_a = rng.normal(0, 1, 1000).tolist()
+    series_b = rng.normal(0.1, 1.2, 1000).tolist()
+    result = calculate_statistical_divergence(series_a, series_b)
+    print("Sample divergence:", result)

--- a/PHM_tools/Decision_making/__init__.py
+++ b/PHM_tools/Decision_making/__init__.py
@@ -1,5 +1,27 @@
-"""Shallow machine learning tools for anomaly detection and fault diagnosis."""
+"""Decision-making tools for predictive maintenance."""
 
 from .decision_tools import isolation_forest_detector, svm_fault_classifier
+from .cost_models import get_maintenance_costs
+from .maintenance_schedulers import generate_maintenance_plan
 
-__all__ = ["isolation_forest_detector", "svm_fault_classifier"]
+__all__ = [
+    "isolation_forest_detector",
+    "svm_fault_classifier",
+    "get_maintenance_costs",
+    "generate_maintenance_plan",
+]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    data = np.random.randn(20, 3)
+    labels = np.random.randint(0, 2, 20)
+    iso_out = isolation_forest_detector(data)
+    svm_out = svm_fault_classifier(data, labels, data)
+    cost = get_maintenance_costs("bearing", {"bearing": {"spare_part_cost": 500}})
+    plan = generate_maintenance_plan({"predicted_rul": 100.0}, cost)
+    print("IsolationForest sample:", iso_out[:5])
+    print("SVM sample:", svm_out[:5])
+    print("Cost lookup sample:", cost)
+    print("Plan sample:", plan)

--- a/PHM_tools/Decision_making/cost_models.py
+++ b/PHM_tools/Decision_making/cost_models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""用于分析与维护相关的成本的工具集。"""
+
+from typing import Dict
+
+from smolagents import tool
+from utils.registry import register_tool
+
+
+@register_tool("get_maintenance_costs")
+@tool
+def get_maintenance_costs(component_id: str, knowledge_base: object) -> Dict[str, float]:
+    """从知识库中检索特定组件的维护相关成本。
+
+    Args:
+        component_id: 需要查询的组件ID或名称。
+        knowledge_base: 一个可以查询结构化数据的知识库接口，需支持 ``get_costs`` 方法或以字典形式提供数据。
+
+    Returns:
+        包含各项成本的字典，例如 ``{"spare_part_cost": 500, "labor_hours": 4}``。
+    """
+    if hasattr(knowledge_base, "get_costs"):
+        return knowledge_base.get_costs(component_id)
+    if isinstance(knowledge_base, dict):
+        costs = knowledge_base.get(component_id)
+        if costs is None:
+            raise KeyError(f"No cost data for component '{component_id}'")
+        return costs
+    raise TypeError("knowledge_base must provide 'get_costs' or behave like a mapping")
+
+
+if __name__ == "__main__":
+    kb = {"bearing": {"spare_part_cost": 500, "labor_hours": 3, "hourly_rate": 80, "downtime_cost_per_hour": 1000}}
+    result = get_maintenance_costs("bearing", kb)
+    print("Sample cost data:", result)

--- a/PHM_tools/Decision_making/decision_tools.py
+++ b/PHM_tools/Decision_making/decision_tools.py
@@ -61,3 +61,13 @@ def svm_fault_classifier(
     X_test = np.asarray(list(x_test))
     clf.fit(X_train, y_train)
     return clf.predict(X_test)
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    demo_data = rng.normal(size=(30, 5))
+    demo_labels = rng.integers(0, 2, size=30)
+    pred_iso = isolation_forest_detector(demo_data)
+    pred_svm = svm_fault_classifier(demo_data, demo_labels, demo_data)
+    print("IsolationForest sample:", pred_iso[:5])
+    print("SVM sample:", pred_svm[:5])

--- a/PHM_tools/Decision_making/maintenance_schedulers.py
+++ b/PHM_tools/Decision_making/maintenance_schedulers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""用于生成最优维护策略的工具集。"""
+
+from typing import Dict
+
+from smolagents import tool
+from utils.registry import register_tool
+
+
+@register_tool("generate_maintenance_plan")
+@tool
+def generate_maintenance_plan(rul_prediction: Dict[str, float | list], cost_data: Dict[str, float]) -> Dict[str, object]:
+    """综合RUL和成本信息，生成一份详细的维护建议。
+
+    Args:
+        rul_prediction: RUL预测结果。
+        cost_data: 相关的成本数据。
+
+    Returns:
+        一份结构化的维护计划，包含建议、理由和预估成本。
+    """
+    predicted_rul = float(rul_prediction.get("predicted_rul", 0.0))
+    spare_cost = cost_data.get("spare_part_cost", 0.0)
+    labor_hours = cost_data.get("labor_hours", 0.0)
+    hourly_rate = cost_data.get("hourly_rate", 0.0)
+    downtime_rate = cost_data.get("downtime_cost_per_hour", 0.0)
+
+    maintenance_cost = spare_cost + labor_hours * hourly_rate
+    downtime_cost = downtime_rate * max(predicted_rul, 0.0)
+    total_cost = maintenance_cost + downtime_cost
+
+    if predicted_rul <= 50:
+        recommendation = "建议立即安排维护，以避免失效。"
+        urgency = "High"
+    elif predicted_rul >= 200:
+        recommendation = "建议按照计划周期进行维护。"
+        urgency = "Low"
+    else:
+        recommendation = "建议在未来 100-120 小时内安排维护。"
+        urgency = "Medium"
+
+    return {
+        "recommendation": recommendation,
+        "reasoning": "该计划综合考虑了RUL预测和维护成本，在失效前进行维护。",
+        "estimated_total_cost": float(total_cost),
+        "urgency_level": urgency,
+    }
+
+
+if __name__ == "__main__":
+    sample_rul = {"predicted_rul": 120.0, "confidence_interval": [100.0, 140.0]}
+    sample_costs = {
+        "spare_part_cost": 500,
+        "labor_hours": 4,
+        "hourly_rate": 80,
+        "downtime_cost_per_hour": 900,
+    }
+    plan = generate_maintenance_plan(sample_rul, sample_costs)
+    print("Sample maintenance plan:", plan)

--- a/PHM_tools/Fault_Diagnosis/__init__.py
+++ b/PHM_tools/Fault_Diagnosis/__init__.py
@@ -1,0 +1,13 @@
+"""Fault diagnosis utilities for PHM_Agent."""
+
+from .classifiers import classify_fault_from_features
+
+__all__ = ["classify_fault_from_features"]
+
+
+if __name__ == "__main__":
+    sample = {"rms": 0.4, "kurtosis": 3.1}
+    from .classifiers import classify_fault_from_features
+
+    res = classify_fault_from_features(sample)
+    print("Classification sample:", res)

--- a/PHM_tools/Fault_Diagnosis/classifiers.py
+++ b/PHM_tools/Fault_Diagnosis/classifiers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""基于预训练模型的故障分类器工具。"""
+
+from typing import Dict
+
+from smolagents import tool
+from utils.registry import register_tool
+
+
+@register_tool("classify_fault_from_features")
+@tool
+def classify_fault_from_features(
+    features: Dict[str, float], model_id: str = "bearing_svm_v2"
+) -> Dict[str, float | str]:
+    """根据输入特征对故障类型进行分类。
+
+    Args:
+        features: 从信号中提取的特征字典。
+        model_id: 预训练模型标识符。
+
+    Returns:
+        最可能的故障标签和置信度, 例如 ``{"fault_label": "outer_ring_fault", "confidence": 0.92}``。
+    """
+    _ = model_id  # Placeholder for real model loading
+    if not features:
+        return {"fault_label": "unknown", "confidence": 0.0}
+    # Here should be the inference logic using the loaded model.
+    return {"fault_label": "outer_ring_fault", "confidence": 0.9}
+
+
+if __name__ == "__main__":
+    sample_features = {"rms": 0.5, "kurtosis": 3.2, "crest_factor": 1.8}
+    result = classify_fault_from_features(sample_features)
+    print("Sample fault classification:", result)

--- a/PHM_tools/Feature_extracting/__init__.py
+++ b/PHM_tools/Feature_extracting/__init__.py
@@ -3,3 +3,13 @@
 from .feature_extractor import extract_time_features, extract_frequency_features
 
 __all__ = ["extract_time_features", "extract_frequency_features"]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    signal = np.random.randn(1_000)
+    time_feats = extract_time_features(signal)
+    freq_feats = extract_frequency_features(signal, fs=1000.0)
+    print("Time feature keys:", list(time_feats.keys())[:3])
+    print("Frequency feature keys:", list(freq_feats.keys())[:3])

--- a/PHM_tools/Feature_extracting/feature_extractor.py
+++ b/PHM_tools/Feature_extracting/feature_extractor.py
@@ -84,6 +84,17 @@ def extract_time_features(signal: list | np.ndarray) -> Dict[str, np.ndarray]:
     return out
 
 
+if __name__ == "__main__":
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    sample = rng.normal(size=1024)
+    time_res = extract_time_features(sample)
+    freq_res = extract_frequency_features(sample, fs=10_000)
+    print("Time feature sample keys:", list(time_res)[:3])
+    print("Frequency feature sample keys:", list(freq_res)[:3])
+
+
 @register_tool("extract_frequency_features")
 @tool
 def extract_frequency_features(signal: list | np.ndarray, fs: float = 1.0) -> Dict[str, np.ndarray]:

--- a/PHM_tools/Prognostics/__init__.py
+++ b/PHM_tools/Prognostics/__init__.py
@@ -1,0 +1,21 @@
+"""Tools for health index generation and RUL prediction."""
+
+from .health_indicators import create_health_index, fit_degradation_model
+from .rul_predictors import predict_rul_from_model
+
+__all__ = [
+    "create_health_index",
+    "fit_degradation_model",
+    "predict_rul_from_model",
+]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    features = {"rms": np.random.rand(10).tolist(), "kurtosis": np.random.rand(10).tolist()}
+    hi = create_health_index(features)
+    model = fit_degradation_model(hi["hi_series"], model_type="linear")
+    rul = predict_rul_from_model(model, failure_threshold=0.1)
+    print("HI sample len:", len(hi["hi_series"]))
+    print("Predicted RUL:", rul)

--- a/PHM_tools/Prognostics/health_indicators.py
+++ b/PHM_tools/Prognostics/health_indicators.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""用于构建和分析设备健康指数（Health Index, HI）的工具集。"""
+
+from typing import Dict, List
+
+import numpy as np
+from sklearn.decomposition import PCA
+from smolagents import tool
+
+from utils.registry import register_tool
+
+
+@register_tool("create_health_index")
+@tool
+def create_health_index(features: Dict[str, List[float]], method: str = "pca") -> Dict[str, object]:
+    """将诊断Agent输出的多维特征融合成一维的健康指数(HI)。
+
+    Args:
+        features: 从诊断Agent获取的特征数据，例如 ``{"rms": [...], "kurtosis": [...]}"。
+        method: 使用的融合算法，可选 ``'pca'`` 或 ``'autoencoder'``。
+
+    Returns:
+        包含HI时间序列及其元数据的字典，例如 ``{"hi_series": [...], "method": "pca"}``。
+    """
+    if not features:
+        return {"hi_series": [], "method": method}
+
+    data = np.column_stack(list(features.values()))
+    if method == "pca":
+        hi = PCA(n_components=1).fit_transform(data).ravel()
+    elif method == "autoencoder":
+        hi = data.mean(axis=1)
+    else:
+        raise ValueError(f"Unsupported method '{method}'")
+    return {"hi_series": hi.tolist(), "method": method}
+
+
+@register_tool("fit_degradation_model")
+@tool
+def fit_degradation_model(hi_series: List[float], model_type: str = "exponential") -> Dict[str, object]:
+    """对健康指数序列拟合退化模型。
+
+    Args:
+        hi_series: 一维的健康指数时间序列。
+        model_type: 拟合模型类型，可选 ``'linear'`` 或 ``'exponential'``。
+
+    Returns:
+        包含模型类型和关键参数的字典，例如 ``{"model_type": "exponential", "decay_rate": -0.05}``。
+    """
+    if not hi_series:
+        raise ValueError("hi_series cannot be empty")
+
+    t = np.arange(len(hi_series))
+    y = np.array(hi_series, dtype=float)
+
+    if model_type == "linear":
+        slope, intercept = np.polyfit(t, y, 1)
+        return {
+            "model_type": "linear",
+            "slope": float(slope),
+            "intercept": float(intercept),
+            "history_length": len(hi_series),
+        }
+
+    if model_type == "exponential":
+        y_clipped = np.clip(y, 1e-9, None)
+        b, a = np.polyfit(t, np.log(y_clipped), 1)
+        return {
+            "model_type": "exponential",
+            "initial": float(np.exp(a)),
+            "decay_rate": float(b),
+            "history_length": len(hi_series),
+        }
+
+    raise ValueError(f"Unsupported model_type '{model_type}'")
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    features = {
+        "rms": rng.normal(1.0, 0.1, 50).tolist(),
+        "kurtosis": rng.normal(3.0, 0.2, 50).tolist(),
+    }
+    hi = create_health_index(features)
+    model = fit_degradation_model(hi["hi_series"], model_type="linear")
+    print("Sample HI:", hi)
+    print("Fitted model:", model)

--- a/PHM_tools/Prognostics/rul_predictors.py
+++ b/PHM_tools/Prognostics/rul_predictors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""用于预测设备剩余使用寿命（RUL）的工具集。"""
+
+import math
+from typing import Dict
+
+from smolagents import tool
+from utils.registry import register_tool
+
+
+@register_tool("predict_rul_from_model")
+@tool
+def predict_rul_from_model(degradation_model: Dict[str, object], failure_threshold: float) -> Dict[str, float | list]:
+    """基于退化模型外推失效时间并计算RUL。
+
+    Args:
+        degradation_model: :func:`fit_degradation_model` 返回的模型参数。
+        failure_threshold: 定义设备失效的健康指数阈值。
+
+    Returns:
+        包含RUL估计值和置信区间的字典，例如 ``{"predicted_rul": 150.5, "confidence_interval": [120.0, 180.0]}``。
+    """
+    model_type = degradation_model.get("model_type")
+    history_len = degradation_model.get("history_length", 0)
+
+    if model_type == "linear":
+        slope = float(degradation_model["slope"])
+        intercept = float(degradation_model["intercept"])
+        if slope >= 0:
+            raise ValueError("Linear degradation slope must be negative")
+        t_failure = (failure_threshold - intercept) / slope
+    elif model_type == "exponential":
+        initial = float(degradation_model["initial"])
+        decay_rate = float(degradation_model["decay_rate"])
+        if decay_rate >= 0:
+            raise ValueError("Decay rate must be negative for degradation")
+        t_failure = math.log(failure_threshold / initial) / decay_rate
+    else:
+        raise ValueError(f"Unsupported model type '{model_type}'")
+
+    rul = t_failure - history_len
+    ci = [rul * 0.9, rul * 1.1]
+    return {"predicted_rul": float(rul), "confidence_interval": [float(ci[0]), float(ci[1])]}
+
+
+if __name__ == "__main__":
+    model = {"model_type": "linear", "slope": -0.01, "intercept": 1.0, "history_length": 100}
+    result = predict_rul_from_model(model, failure_threshold=0.2)
+    print("Sample RUL prediction:", result)

--- a/PHM_tools/Retrieval/__init__.py
+++ b/PHM_tools/Retrieval/__init__.py
@@ -1,5 +1,6 @@
 from .retriever import build_vector_store, create_retriever_tool, RetrieverTool
 from .local_knowledge import build_local_vector_store, create_local_retriever_tool
+from .knowledge_base import VectorKnowledgeBaseManager
 
 __all__ = [
     "build_vector_store",
@@ -7,4 +8,26 @@ __all__ = [
     "RetrieverTool",
     "build_local_vector_store",
     "create_local_retriever_tool",
+    "VectorKnowledgeBaseManager",
 ]
+
+
+if __name__ == "__main__":
+    from langchain.docstore.document import Document
+    from langchain.vectorstores import Chroma
+
+    class RandomEmbeddings:
+        def embed_documents(self, docs):
+            import numpy as np
+
+            return [np.random.random(8).tolist() for _ in docs]
+
+        def embed_query(self, _q):
+            import numpy as np
+
+            return np.random.random(8).tolist()
+
+    docs = [Document(page_content=f"doc {i}") for i in range(3)]
+    store = Chroma.from_documents(docs, RandomEmbeddings())
+    tool = RetrieverTool(store)
+    print(tool("doc"))

--- a/PHM_tools/Retrieval/knowledge_base.py
+++ b/PHM_tools/Retrieval/knowledge_base.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Vector knowledge base manager for storing PHM findings."""
+
+from typing import Any, Dict, List
+
+import datetime
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+class VectorKnowledgeBaseManager:
+    """Manage and query vectorized findings."""
+
+    def __init__(self, embedding_model_name: str = "all-MiniLM-L6-v2") -> None:
+        self.embedding_model = SentenceTransformer(embedding_model_name)
+        dim = self.embedding_model.get_sentence_embedding_dimension()
+        self.vector_index = faiss.IndexFlatL2(dim)
+        self.findings_metadata: List[Dict[str, Any]] = []
+
+    def add_finding(
+        self, finding_text: str, source_agent: str, confidence: float, evidence_keys: List[str]
+    ) -> str:
+        """Store ``finding_text`` with metadata and return its ID."""
+        finding_id = f"finding_{len(self.findings_metadata) + 1}_{int(datetime.datetime.now().timestamp())}"
+        record = {
+            "id": finding_id,
+            "timestamp": datetime.datetime.now().isoformat(),
+            "text": finding_text,
+            "source": source_agent,
+            "confidence": confidence,
+            "evidence": evidence_keys,
+        }
+        self.findings_metadata.append(record)
+        vec = self.embedding_model.encode([finding_text]).astype("float32")
+        self.vector_index.add(vec)
+        return finding_id
+
+    def query_similar_findings(self, query_text: str, top_k: int = 3) -> List[Dict[str, Any]]:
+        """Return findings most similar to ``query_text``."""
+        if self.vector_index.ntotal == 0:
+            return []
+        q_vec = self.embedding_model.encode([query_text]).astype("float32")
+        distances, indices = self.vector_index.search(q_vec, top_k)
+        results = []
+        for i, idx in enumerate(indices[0]):
+            result = self.findings_metadata[idx].copy()
+            result["similarity_score"] = 1 - float(distances[0][i])
+            results.append(result)
+        return results
+
+
+if __name__ == "__main__":
+    kb = VectorKnowledgeBaseManager()
+    fid = kb.add_finding("demo finding", "demo_agent", 0.8, ["e1"])
+    print("Added finding", fid)
+    print("Query result:", kb.query_similar_findings("demo"))

--- a/PHM_tools/Retrieval/local_knowledge.py
+++ b/PHM_tools/Retrieval/local_knowledge.py
@@ -94,3 +94,14 @@ def create_local_retriever_tool(
     """
     store = build_local_vector_store(directory, persist_directory=persist_directory)
     return RetrieverTool(store)
+
+
+if __name__ == "__main__":
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "sample.txt"
+        path.write_text("simple demo document")
+        store = build_local_vector_store(tmp, persist_directory=tmp)
+        tool = RetrieverTool(store)
+        print(tool("demo"))

--- a/PHM_tools/Retrieval/retriever.py
+++ b/PHM_tools/Retrieval/retriever.py
@@ -114,3 +114,24 @@ def create_retriever_tool(persist_directory: str = "./chroma_db") -> RetrieverTo
     """
     vector_store = build_vector_store(persist_directory=persist_directory)
     return RetrieverTool(vector_store)
+
+
+if __name__ == "__main__":
+    from tempfile import TemporaryDirectory
+    from langchain.docstore.document import Document
+    from langchain.vectorstores import Chroma
+
+    class RandomEmbeddings:
+        def embed_documents(self, docs):
+            import numpy as np
+            return [np.random.random(8).tolist() for _ in docs]
+
+        def embed_query(self, _):
+            import numpy as np
+            return np.random.random(8).tolist()
+
+    with TemporaryDirectory() as tmp:
+        docs = [Document(page_content="test doc")] 
+        store = Chroma.from_documents(docs, RandomEmbeddings())
+        tool = RetrieverTool(store)
+        print(tool("test"))

--- a/PHM_tools/Signal_processing/SP_1D/__init__.py
+++ b/PHM_tools/Signal_processing/SP_1D/__init__.py
@@ -17,3 +17,13 @@ __all__ = [
     "cepstrum",
     "envelope_spectrum",
 ]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    sig = np.random.randn(500)
+    filtered = bandpass(sig, fs=1000, low=10, high=200)
+    spec = fft(filtered)
+    print("Bandpass sample shape:", filtered.shape)
+    print("FFT sample shape:", spec.shape)

--- a/PHM_tools/Signal_processing/SP_1D/signal_processing_1d.py
+++ b/PHM_tools/Signal_processing/SP_1D/signal_processing_1d.py
@@ -116,3 +116,13 @@ def envelope_spectrum(signal: list | np.ndarray) -> np.ndarray:
     analytic = scipy.signal.hilbert(x, axis=1)
     env = np.abs(analytic)
     return fft(env)
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    sig = rng.normal(size=1024)
+    filtered = bandpass(sig, fs=1000, low=5, high=200)
+    spec = fft(filtered)
+    env_spec = envelope_spectrum(filtered)
+    print("FFT result shape:", spec.shape)
+    print("Envelope spectrum shape:", env_spec.shape)

--- a/PHM_tools/Signal_processing/SP_2D/__init__.py
+++ b/PHM_tools/Signal_processing/SP_2D/__init__.py
@@ -21,3 +21,13 @@ __all__ = [
     "cepstrogram",
     "envelope_spectrogram",
 ]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    sig = np.random.randn(256)
+    spec, _ = spectrogram(sig, fs=1000)
+    scal = scalogram(sig, fs=1000)
+    print("Spectrogram shape:", spec.shape)
+    print("Scalogram shape:", scal.shape)

--- a/PHM_tools/Signal_processing/SP_2D/signal_processing_2d.py
+++ b/PHM_tools/Signal_processing/SP_2D/signal_processing_2d.py
@@ -258,3 +258,12 @@ def envelope_spectrogram(
     env = np.abs(analytic)
     return spectrogram(env, fs=fs, nperseg=nperseg, noverlap=noverlap)
 
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    signal = rng.normal(size=2048)
+    spec = spectrogram(signal, fs=1000)
+    mel = mel_spectrogram(signal, fs=1000)
+    print("Spectrogram shape:", spec.shape)
+    print("Mel-spectrogram shape:", mel.shape)
+

--- a/PHM_tools/Signal_processing/__init__.py
+++ b/PHM_tools/Signal_processing/__init__.py
@@ -18,6 +18,7 @@ from .SP_2D import (
     cepstrogram,
     envelope_spectrogram,
 )
+from .slicer_tools import apply_transform, extract_slice
 
 __all__ = [
     "normalize",
@@ -34,4 +35,16 @@ __all__ = [
     "recurrence_plot",
     "cepstrogram",
     "envelope_spectrogram",
+    "apply_transform",
+    "extract_slice",
 ]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    signal = np.random.randn(1024)
+    norm = normalize(signal)
+    spec = spectrogram(signal, fs=1000)[0]
+    print("Normalized sample shape:", norm.shape)
+    print("Spectrogram sample shape:", spec.shape)

--- a/PHM_tools/Signal_processing/slicer_tools.py
+++ b/PHM_tools/Signal_processing/slicer_tools.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Signal slicing utilities for PHM workflows."""
+
+from typing import Any, Dict
+
+from PHM_tools.Signal_processing import normalize
+from PHM_tools.data_management import DataManager
+
+
+def apply_transform(
+    data_manager: DataManager,
+    source_data_key: str,
+    transform_tool_name: str,
+    transform_params: Dict[str, Any],
+) -> str:
+    """Apply a transformation to stored data and save the result.
+
+    Args:
+        data_manager: Central data manager instance.
+        source_data_key: Key of the source data in :class:`DataManager`.
+        transform_tool_name: Name of the tool to apply (e.g., ``'normalize'``).
+        transform_params: Parameters passed to the tool.
+
+    Returns:
+        Key under which the transformed data is stored.
+    """
+    data = data_manager.get_processed_data(source_data_key)
+    if data is None:
+        raise KeyError(f"Data key '{source_data_key}' not found")
+
+    # In a real system we'd lookup the tool dynamically. Here we demo with 'normalize'.
+    if transform_tool_name == "normalize":
+        transformed = normalize(data)
+    else:
+        raise ValueError(f"Unsupported transform '{transform_tool_name}'")
+
+    new_key = f"{source_data_key}_{transform_tool_name}"
+    data_manager.store_processed_data(new_key, transformed)
+    return new_key
+
+
+def extract_slice(
+    data_manager: DataManager, source_data_key: str, slice_params: Dict[str, Any]
+) -> str:
+    """Extract a slice from stored data using ``slice`` semantics.
+
+    Args:
+        data_manager: Central data manager instance.
+        source_data_key: Key of the data to slice.
+        slice_params: Slice specification, e.g., ``{"start": 0, "stop": 10}``.
+
+    Returns:
+        Key under which the slice is stored.
+    """
+    data = data_manager.get_processed_data(source_data_key)
+    if data is None:
+        raise KeyError(f"Data key '{source_data_key}' not found")
+
+    start = slice_params.get("start")
+    stop = slice_params.get("stop")
+    sliced = data[start:stop]
+
+    new_key = f"{source_data_key}_slice_{start}_{stop}"
+    data_manager.store_processed_data(new_key, sliced)
+    return new_key
+
+
+if __name__ == "__main__":
+    import numpy as np
+    import tempfile
+    import pandas as pd
+    import h5py
+
+    rng = np.random.default_rng(0)
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as tmp_csv:
+        pd.DataFrame({"id": ["x"], "label": ["demo"]}).to_csv(tmp_csv.name, index=False)
+        csv_path = tmp_csv.name
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_h5:
+        with h5py.File(tmp_h5.name, "w") as f:
+            f.create_dataset("x", data=rng.normal(size=20))
+        h5_path = tmp_h5.name
+
+    dm = DataManager(csv_path, h5_path)
+    dm.store_processed_data("raw", rng.normal(size=20))
+    key_norm = apply_transform(dm, "raw", "normalize", {})
+    key_slice = extract_slice(dm, key_norm, {"start": 0, "stop": 5})
+    print("Slice key:", key_slice, "data:", dm.get_processed_data(key_slice))

--- a/PHM_tools/__init__.py
+++ b/PHM_tools/__init__.py
@@ -20,7 +20,19 @@ from .Signal_processing import (
     cepstrogram,
     envelope_spectrogram,
 )
-from .Decision_making import isolation_forest_detector, svm_fault_classifier
+from .Prognostics import (
+    create_health_index,
+    fit_degradation_model,
+    predict_rul_from_model,
+)
+from .Decision_making import (
+    isolation_forest_detector,
+    svm_fault_classifier,
+    get_maintenance_costs,
+    generate_maintenance_plan,
+)
+from .Anomaly_Detection import calculate_statistical_divergence
+from .Fault_Diagnosis import classify_fault_from_features
 from .text_web_browser import (
     SimpleTextBrowser,
     VisitTool,
@@ -39,6 +51,9 @@ from .Retrieval import (
     build_local_vector_store,
     create_local_retriever_tool,
 )
+from .data_management import DataManager
+from .Retrieval.knowledge_base import VectorKnowledgeBaseManager
+from .Signal_processing.slicer_tools import apply_transform, extract_slice
 
 __all__ = [
     "extract_time_features",
@@ -57,8 +72,15 @@ __all__ = [
     "recurrence_plot",
     "cepstrogram",
     "envelope_spectrogram",
+    "create_health_index",
+    "fit_degradation_model",
+    "predict_rul_from_model",
+    "calculate_statistical_divergence",
+    "classify_fault_from_features",
     "isolation_forest_detector",
     "svm_fault_classifier",
+    "get_maintenance_costs",
+    "generate_maintenance_plan",
     "RetrieverTool",
     "build_vector_store",
     "create_retriever_tool",
@@ -72,4 +94,18 @@ __all__ = [
     "FindNextTool",
     "ArchiveSearchTool",
     "TextInspectorTool",
+    "DataManager",
+    "VectorKnowledgeBaseManager",
+    "apply_transform",
+    "extract_slice",
 ]
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    sig = np.random.randn(500)
+    norm_sig = normalize(sig)
+    features = extract_time_features(norm_sig)
+    print("Normalized signal shape:", norm_sig.shape)
+    print("Extracted feature keys:", list(features)[:3])

--- a/PHM_tools/data_management.py
+++ b/PHM_tools/data_management.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Central data manager for PHM tools.
+
+This module defines :class:`DataManager`, a utility responsible for loading raw
+signal data and metadata and storing intermediate processing results.
+"""
+
+from typing import Any, Dict, List
+
+import h5py
+import numpy as np
+import pandas as pd
+
+
+class DataManager:
+    """Manage signal metadata and processed data."""
+
+    def __init__(self, metadata_path: str, signal_data_path: str) -> None:
+        self.metadata_df = pd.read_csv(metadata_path).set_index("id")
+        self.signal_data_path = signal_data_path
+        self.processed_data_cache: Dict[str, Any] = {}
+
+    def get_all_ids(self, label: str | None = None) -> List[str]:
+        df = self.metadata_df
+        if label is not None:
+            df = df[df["label"] == label]
+        return df.index.astype(str).tolist()
+
+    def get_signal_by_id(self, signal_id: str) -> Dict[str, np.ndarray]:
+        with h5py.File(self.signal_data_path, "r") as f:
+            if signal_id not in f:
+                raise KeyError(f"Signal ID '{signal_id}' not found")
+            data = f[signal_id][:]
+        return {signal_id: data}
+
+    def get_metadata_by_id(self, signal_id: str) -> Dict[str, Any]:
+        return self.metadata_df.loc[signal_id].to_dict()
+
+    def store_processed_data(self, key: str, data: Any) -> None:
+        self.processed_data_cache[key] = data
+
+    def get_processed_data(self, key: str) -> Any:
+        return self.processed_data_cache.get(key)
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    rng = np.random.default_rng(0)
+    # create temporary metadata CSV
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as tmp_csv:
+        pd.DataFrame({"id": ["a", "b"], "label": ["normal", "fault"]}).to_csv(tmp_csv.name, index=False)
+        metadata_path = tmp_csv.name
+
+    # create temporary HDF5 with random signals
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_h5:
+        with h5py.File(tmp_h5.name, "w") as f:
+            f.create_dataset("a", data=rng.normal(size=100))
+            f.create_dataset("b", data=rng.normal(size=100))
+        data_path = tmp_h5.name
+
+    dm = DataManager(metadata_path, data_path)
+    ids = dm.get_all_ids()
+    sig = dm.get_signal_by_id(ids[0])
+    print("IDs:", ids)
+    print("Signal sample shape:", sig[ids[0]].shape)

--- a/PHM_tools/model_download.py
+++ b/PHM_tools/model_download.py
@@ -25,3 +25,8 @@ def model_download_tool(task: str) -> str:
     if not models:
         raise ValueError(f"No models found for task '{task}'")
     return models[0].modelId
+
+
+if __name__ == "__main__":
+    result = model_download_tool("text-classification")
+    print("Top model id:", result)

--- a/PHM_tools/text_inspector_tool.py
+++ b/PHM_tools/text_inspector_tool.py
@@ -86,4 +86,10 @@ class TextInspectorTool(Tool):
         return self.model(messages).content
 
 
+if __name__ == "__main__":
+    tool = TextInspectorTool()
+    content = tool.forward(__file__)
+    print("First 60 chars:\n", content[:60])
+
+
 __all__ = ["TextInspectorTool"]

--- a/PHM_tools/text_web_browser.py
+++ b/PHM_tools/text_web_browser.py
@@ -318,3 +318,8 @@ __all__ = [
     "FindNextTool",
     "ArchiveSearchTool",
 ]
+
+
+if __name__ == "__main__":
+    browser = SimpleTextBrowser(start_page="about:blank")
+    print("Initial address:", browser.address)

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Agent orchestrators for PHM_Agent."""
+
+from .phm_analysis_agent import PHMAnalysisAgent
+from .phm_strategy_agent import create_phm_strategy_agent
+from .manager_agent import ManagerAgent
+
+__all__ = ["PHMAnalysisAgent", "create_phm_strategy_agent", "ManagerAgent"]

--- a/agents/manager_agent.py
+++ b/agents/manager_agent.py
@@ -1,0 +1,97 @@
+"""Top-level manager delegating analysis to ``PHMAnalysisAgent``."""
+from __future__ import annotations
+
+from smolagents.agents import CodeAgent
+from smolagents.models import Model
+
+from utils.registry import register_agent, TOOL_REGISTRY
+from agents.phm_analysis_agent import PHMAnalysisAgent
+from agents.phm_strategy_agent import create_phm_strategy_agent
+from PHM_tools.data_management import DataManager
+from PHM_tools.Retrieval.knowledge_base import VectorKnowledgeBaseManager
+
+
+@register_agent("ManagerAgent")
+class ManagerAgent(CodeAgent):
+    """Top-level agent orchestrating analysis and planning stages."""
+
+    def __init__(self, model: Model, **kwargs) -> None:
+        all_tools = list(TOOL_REGISTRY.values())
+        analysis_agent = PHMAnalysisAgent(
+            tools=all_tools,
+            model=model,
+            return_full_result=True,
+            add_base_tools=True,
+        )
+        strategy_agent = create_phm_strategy_agent(model)
+
+        instructions = (
+            "先调用PHMAnalysisAgent进行诊断，如有异常再调用PHMStrategyAgent制定维护计划。"
+        )
+        super().__init__(
+            tools=[],
+            model=model,
+            managed_agents=[analysis_agent, strategy_agent],
+            name="manager_agent",
+            description="Delegates PHM analysis and planning",
+            instructions=instructions,
+            return_full_result=True,
+            add_base_tools=True,
+            **kwargs,
+        )
+        self.analysis_agent = analysis_agent
+        self.strategy_agent = strategy_agent
+
+    def run_workflow(self, task_input: dict) -> object:
+        """Run the PHM analysis workflow.
+
+        Args:
+            task_input: Dictionary containing ``metadata_path``, ``signal_path``,
+                ``reference_ids`` and ``test_id``.
+
+        Returns:
+            Analysis results or maintenance plan depending on detected status.
+        """
+        dm = DataManager(task_input["metadata_path"], task_input["signal_path"])
+        kb = VectorKnowledgeBaseManager()
+        payload = {
+            "data_manager": dm,
+            "kb_manager": kb,
+            "reference_ids": task_input.get("reference_ids", []),
+            "test_id": task_input.get("test_id"),
+        }
+        diagnostic_report = self.analysis_agent.run(payload)
+        if isinstance(diagnostic_report, dict):
+            status = diagnostic_report.get("status")
+            if status and status != "NORMAL" or "fault_label" in diagnostic_report:
+                return self.strategy_agent.run({"diagnostic_report": diagnostic_report})
+        return diagnostic_report
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    import numpy as np
+    import pandas as pd
+    import h5py
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as tmp_csv:
+        pd.DataFrame({"id": ["demo"], "label": ["normal"]}).to_csv(tmp_csv.name, index=False)
+        csv_path = tmp_csv.name
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_h5:
+        with h5py.File(tmp_h5.name, "w") as f:
+            f.create_dataset("demo", data=np.random.randn(50))
+        h5_path = tmp_h5.name
+
+    manager = ManagerAgent(DummyModel())
+    payload = {
+        "metadata_path": csv_path,
+        "signal_path": h5_path,
+        "reference_ids": ["demo"],
+        "test_id": "demo",
+    }
+    result = manager.run_workflow(payload)
+    print("Workflow result:", result)

--- a/agents/phm_analysis_agent.py
+++ b/agents/phm_analysis_agent.py
@@ -1,0 +1,55 @@
+"""Dynamic analysis agent orchestrating PHM workflows."""
+from __future__ import annotations
+
+from smolagents.agents import CodeAgent
+from smolagents.models import Model
+from smolagents.tools import Tool
+
+from utils.registry import register_agent
+
+SYSTEM_PROMPT = """
+你的身份是'PHM总工程师'，一个负责领导一个由“微服务化”虚拟专家组成的、包含研究与检索能力的完整团队来解决复杂诊断任务的专家。
+
+## 核心资产与初始上下文
+在每次运行时，你将接收到以下核心资产：
+1. `data_manager`: 中央数据管理器实例。
+2. `kb_manager`: 中央向量知识库管理器实例。
+3. `reference_ids`: 参考信号ID列表。
+4. `test_id`: 需要分析的目标信号ID。
+5. 可用的专家团队: SP1D_SpecialistAgent, SP2D_SpecialistAgent, StatsFeatureAgent, PhysicalFeatureAgent, DeepResearchAgent, RetrievalAgent。
+
+## 核心思考原则：知识驱动的、可溯源的专家委托
+你的工作是规划并委托任务给专家团队，并将他们的发现通过 `kb_manager` 进行语义化存储和对齐。
+你通过对知识库的语义查询来关联历史经验，并利用 `slicer_tools` 进行特征溯源，最终构建可追溯的证据链。
+
+## 主要工作流程（高度动态的专家协作与特征溯源）
+1. **初步分析与异常检测**：委托 StatsFeatureAgent 等专家提取特征并判断是否异常。
+2. **深度诊断与特征溯源**：若发现异常，使用 SP1D/SP2D 专家与 slicer_tools 追踪异常来源，并让 PhysicalFeatureAgent 进行物理分析。
+3. **知识关联与深度研究**：通过 kb_manager 查询相似案例，如有需要调用 DeepResearchAgent 进一步研究。
+4. **最终决策与报告生成**：综合知识库信息，形成诊断结论并生成 Monitoring_Report.md。
+"""
+
+
+@register_agent("PHM_Analysis_Agent")
+class PHMAnalysisAgent(CodeAgent):
+    """Core agent capable of dynamic planning using PHM tools."""
+
+    def __init__(self, tools: list[Tool], model: Model, **kwargs) -> None:
+        instructions = SYSTEM_PROMPT
+        super().__init__(
+            tools=tools,
+            model=model,
+            name="phm_analysis_agent",
+            description="Dynamic PHM analysis agent",
+            instructions=instructions,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = PHMAnalysisAgent(tools=[], model=DummyModel())
+    print("Created analysis agent:", agent.name)

--- a/agents/phm_strategy_agent.py
+++ b/agents/phm_strategy_agent.py
@@ -1,0 +1,64 @@
+"""
+PHM_Strategy_Agent: 负责编排预测与规划工作流的高级Agent。
+"""
+from __future__ import annotations
+
+from smolagents import ToolCallingAgent
+
+from PHM_tools.Prognostics.health_indicators import (
+    create_health_index,
+    fit_degradation_model,
+)
+from PHM_tools.Prognostics.rul_predictors import predict_rul_from_model
+from PHM_tools.Decision_making.cost_models import get_maintenance_costs
+from PHM_tools.Decision_making.maintenance_schedulers import generate_maintenance_plan
+
+SYSTEM_PROMPT = """
+你的身份是'PHM战略规划师'，一个负责设备长期健康管理和维护决策的专家。你的工作是严格遵循一个清晰、逻辑严密的工作流来制定计划。**你唯一的任务就是按顺序调用已有的工具，将前一步的输出作为下一步的输入。**
+
+**工作流指令:**
+1.  **接收输入**: 你将从ManagerAgent处接收到`diagnostic_report`，其中包含了故障诊断结果和信号特征。
+2.  **评估健康状态**:
+    - 调用 `create_health_index` 将特征融合成健康指数(HI)。
+    - 调用 `fit_degradation_model` 对HI序列进行建模，得到`degradation_model`。
+3.  **预测未来趋势**:
+    - 调用 `predict_rul_from_model`，并传入`degradation_model`和一个预设的`failure_threshold`，得到`rul_prediction`。
+4.  **制定维护计划**:
+    - 调用 `get_maintenance_costs` 获取相关成本信息。
+    - 调用 `generate_maintenance_plan`，综合`rul_prediction`和成本信息，生成最终的`maintenance_plan`。
+5.  **输出结果**: 将最终的`maintenance_plan`作为你的最终答案返回。
+"""
+
+
+def create_phm_strategy_agent(model) -> ToolCallingAgent:
+    """创建并配置PHM战略规划师Agent。
+
+    Args:
+        model: 用于驱动Agent的大语言模型实例。
+
+    Returns:
+        一个配置好工具和指令的ToolCallingAgent实例。
+    """
+    prognostics_and_planning_tools = [
+        create_health_index,
+        fit_degradation_model,
+        predict_rul_from_model,
+        get_maintenance_costs,
+        generate_maintenance_plan,
+    ]
+
+    strategy_agent = ToolCallingAgent(
+        model=model,
+        tools=prognostics_and_planning_tools,
+        prompt_templates={"system": SYSTEM_PROMPT},
+    )
+    return strategy_agent
+
+
+if __name__ == "__main__":
+    class DummyModel:
+        def __call__(self, messages):
+            return type("Obj", (), {"content": "ok"})()
+
+    agent = create_phm_strategy_agent(DummyModel())
+    print("Strategy agent created with", len(agent.tools), "tools")

--- a/agents_config.py
+++ b/agents_config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from smolagents import CodeAgent, ToolCallingAgent, VisitWebpageTool, WebSearchTool
 from smolagents.models import Model
 
+from agents.manager_agent import ManagerAgent
+
 from PHM_tools.Retrieval.retriever import create_retriever_tool
 from utils.registry import get_agent, get_tool
 from Agent import create_deep_research_agent
@@ -63,39 +65,23 @@ AGENT_BUILDERS = {
 }
 
 
-def create_manager_agent(model: Model, config=None) -> CodeAgent:
-    """Return a manager agent composed of configurable sub agents.
+def create_manager_agent(model: Model, config=None) -> ManagerAgent:
+    """Return the high-level :class:`ManagerAgent` used by the demos.
 
-    Parameters
-    ----------
-    model:
-        Model instance created via :func:`model_config.configure_model`.
-    config:
-        Optional configuration object with additional settings. Must contain
-        ``enabled_agents`` listing the agents to include.
+    The previous implementation dynamically composed a manager from several
+    sub-agents. The new architecture encapsulates this logic inside
+    :class:`ManagerAgent`, so this function simply instantiates that class.
+
+    Args:
+        model: Configured language model instance.
+        config: Optional configuration object (unused).
+
+    Returns:
+        Instance of :class:`ManagerAgent` ready for interaction.
     """
 
-    enabled = getattr(
-        config,
-        "enabled_agents",
-        ["search_agent", "phm_agent", "retrieval_agent"],
-    )
-
-    sub_agents: list[ToolCallingAgent | CodeAgent] = [
-        AGENT_BUILDERS[name](model) for name in enabled if name in AGENT_BUILDERS
-    ]
-
-    manager_agent = CodeAgent(
-        tools=[],
-        model=model,
-        managed_agents=sub_agents,
-        name="manager_agent",
-        description="Orchestrates sub-agents to answer PHM queries.",
-        instructions="Coordinate all sub agents to deliver a complete PHM analysis.",
-        return_full_result=True,
-        add_base_tools=True,
-    )
-    return manager_agent
+    _ = config
+    return ManagerAgent(model)
 
 
 # def create_rag_agent(model: Model, vector_store) -> CodeAgent:

--- a/main.py
+++ b/main.py
@@ -44,11 +44,31 @@ def main(config: str = "config.yaml", inspect: bool = False, ui: bool = False) -
         ).launch()
         return
 
-    run_result = manager_agent.run(
-        "If the US keeps it 2024 growth rate, how many years would it take for the GDP to double?"
-    )
-    print("Here is the token usage for the manager agent", run_result.token_usage)
-    print("Here are the timing informations for the manager agent:", run_result.timing)
+    import numpy as np
+    import pandas as pd
+    import h5py
+    import tempfile
+
+    rng = np.random.default_rng(0)
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as tmp_csv:
+        pd.DataFrame({"id": ["demo"], "label": ["normal"]}).to_csv(
+            tmp_csv.name, index=False
+        )
+        csv_path = tmp_csv.name
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_h5:
+        with h5py.File(tmp_h5.name, "w") as f:
+            f.create_dataset("demo", data=rng.normal(size=50))
+        h5_path = tmp_h5.name
+
+    payload = {
+        "metadata_path": csv_path,
+        "signal_path": h5_path,
+        "reference_ids": ["demo"],
+        "test_id": "demo",
+    }
+
+    run_result = manager_agent.run_workflow(payload)
+    print("Workflow result:", run_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add runtime demos to remaining modules
- simplify manager creation via new ManagerAgent
- update main entrypoint to run a sample PHM workflow
- include testing hooks in package init modules

## Testing
- `pip install ipython`
- `pytest -q` *(fails: tests expecting image handling tools and blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6880fdf9f7fc832380abb0657f2929a0